### PR TITLE
Added contributing.md file.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,19 @@
-For ideas on what to contribute you can:
+##Ways to contribute to PeerLibrary
 
-* check the [roadmap and milestones](https://github.com/peerlibrary/peerlibrary/issues/milestones)
-  and related open issues
-* check `TODO` comments in the code: there are quite some of them which are of "here is a
-  dirty hack, do a real implementation" kind, those are a good start to contribute;
-  while some other have to wait for other things to be done first
-* while reading the code if you do not understand anything, feel free to ask and then
-  contribute a comment describing the code so that the next person will understand
+* contribute to the PeerLibrary source repository. For specific ideas:
+    * check the [roadmap and milestones](https://github.com/peerlibrary/peerlibrary/issues/milestones) and related open issues. See especially the "for-new-contributors" label. If you would like to work on an issue, assign yourself to that issue.
+    * check `TODO` comments in the code: there are quite a number of them which are of the "here is a dirty hack, do a real implementation" kind, which are a good way to start contributing. Some other TODOs will require waiting/coordination for other things to be done first
+    * while reading the code if you do not understand anything, feel free to ask and then contribute a comment describing the code so that the next person will understand
+    * changes made to the PeerLibrary source repository should include:
+        1. The code implementation
+        2. Tests run locally and on [Travis CI](https://travis-ci.org/) (not yet provided)
+        3. Quality documentation
+    * Note that you will need to sign our Contributor Agreement in order to submit contributions (not yet provided)
+
 * read (and contribute to) our [wiki](https://github.com/peerlibrary/peerlibrary/wiki)
-* if you have your favorite open access journal or repository not yet integrated into
-  PeerLibrary, add support for it; this goes especially for possible non-English open
-  access journals or repositories we might not even know about; you can just
-  [open an issue for it](https://github.com/peerlibrary/peerlibrary/issues/new) to let
-  us know
-* advocate at your local university to open its publications to be able to integrate
-  into PeerLibrary
+* contribute to the PeerLibrary source repository
+* if you have your favorite open access journal or repository not yet integrated into PeerLibrary, add support for it; this goes especially for possible non-English open access journals or repositories we might not even know about; you can just [open an issue for it](https://github.com/peerlibrary/peerlibrary/issues/new) to let us know
+* advocate at your local university to open its publications to be able to integrate into PeerLibrary
 
 
 See [this tutorial](https://help.github.com/articles/fork-a-repo) to find out how to fork and contribute to an existing repository.


### PR DESCRIPTION
When information about contributing be in a separate file called contributing.md, GitHub will [automatically show a link to this file](https://help.github.com/articles/how-do-i-set-up-guidelines-for-contributors) whenever someone opens a pull request or submits an issue.
