### PR TITLE
Add a way to pause the background animation #220

### DIFF
--- a/client/css/variables.import.styl
+++ b/client/css/variables.import.styl
@@ -7,6 +7,7 @@ blue = #338ed5
 blue-accent = #2270ab
 white-translucent = rgba(240,240,240,0.6)
 overlay-translucent = rgba(46,46,44,0.5)
+/* Used also in background.coffee, keep in sync */
 light-grey = #f6f8f8
 
 selection-color = rgba(0,90,160,0.2)

--- a/client/footer.coffee
+++ b/client/footer.coffee
@@ -10,12 +10,13 @@ Template.footer.indexFooter = ->
 Template.footer.noIndexFooter = ->
   'no-index-footer' if not Template.footer.indexFooter()
 
-Session.setDefault 'backgroundPaused', false
+Meteor.startup ->
+  Session.setDefault 'backgroundPaused', false
 
-Template.backgroundPauseButton.events
-  'click': (e, template) ->
+Template.backgroundPause.events
+  'click button': (e, template) ->
     Session.set('backgroundPaused', not Session.get 'backgroundPaused')
     return # Make sure CoffeeScript does not return anything
 
-Template.backgroundPauseButton.backgroundPaused = ->
+Template.backgroundPause.backgroundPaused = ->
   Session.get 'backgroundPaused'

--- a/client/lib/background.coffee
+++ b/client/lib/background.coffee
@@ -34,7 +34,6 @@ class Vector
     @deltaY = 0
 
   update: (time) =>
-    return if Session.get 'backgroundPaused'
     distance = Math.sin(Math.min(Math.abs(@originY + 0.5 * @originX + 150 - (time / 2) / 5 % (Math.max(window.innerWidth, window.innerHeight) + 300)) / Math.sqrt(1.25), 200) / 200 * Math.PI / 2) * 60
     if not @duration or time > @start + @duration
       @start = time
@@ -83,10 +82,17 @@ class @Background
   constructor: ->
     @renderer = PIXI.autoDetectRenderer window.innerWidth, window.innerHeight
     @computeRatio()
+    @clearBackground()
 
+    # We randomize start time so that it is not always the same, which
+    # also helps when background is paused that it looks different every time
+    @randomizedStart = Math.random() * 10000 + 10000
     @stage = null
     @triangles = {}
     @vectors = {}
+    @pausedTime = 0
+    @pausedDelay = 0
+    @autorunHandle = null
 
   destroy: =>
     @renderer = null
@@ -95,6 +101,10 @@ class @Background
     @stage = null
     @triangles = {}
     @vectors = {}
+    @pausedTime = 0
+    @pausedDelay = 0
+    @autorunHandle.stop() if @autorunHandle
+    @autorunHandle = null
 
   computeRatio: =>
     devicePixelRatio = window.devicePixelRatio or 1
@@ -106,6 +116,14 @@ class @Background
                         context.oBackingStorePixelRatio or 1
 
     @ratio = devicePixelRatio / backingStoreRatio
+
+  clearBackground: =>
+    # Used also in variables.import.styl, keep in sync
+    stage = new PIXI.Stage 0xf6f8f8
+    graphics = new PIXI.Graphics()
+    stage.addChild graphics
+    graphics.clear()
+    @renderer.render stage
 
   render: =>
     @resizeView()
@@ -181,10 +199,29 @@ class @Background
   draw: (time) =>
     return unless @renderer
 
-    return if Session.get 'backgroundPaused'
+    if not Session.get('backgroundPaused') and @autorunHandle
+      # Cleanup after resume (again, just to be sure)
+      @autorunHandle.stop()
+      @autorunHandle = null
 
-    vector.update time for key, vector of @vectors
+    @pausedDelay += time - @pausedTime if @pausedTime isnt 0
+    @pausedTime = 0
+
+    vector.update time - @pausedDelay + @randomizedStart for key, vector of @vectors
     triangle.draw() for key, triangle of @triangles
     @renderer.render @stage
+
+    if Session.get 'backgroundPaused'
+      # Remember the time when we were paused
+      @pausedTime = time
+      # And react to the change of backgroundPaused
+      @autorunHandle = Deps.autorun =>
+        unless Session.get 'backgroundPaused'
+          # Cleanup after resume
+          @autorunHandle.stop()
+          @autorunHandle = null
+          # Restart the loop
+          frame @draw
+      return
 
     frame @draw

--- a/client/templates/footer.html
+++ b/client/templates/footer.html
@@ -9,23 +9,25 @@
       <li><a href="https://github.com/peerlibrary/peerlibrary/wiki/Public-API">API</a></li>
     </ul>
     <ul class="connect">
-      <li>{{> backgroundPauseButton}}</li>
       <li><a href="http://blog.peerlibrary.org">Blog</a></li>
       <li><a href="https://twitter.com/PeerLibrary">Twitter</a></li>
       <li><a href="http://lists.peerlibrary.org/lists/info/news" class="newsletter">Newsletter</a></li>
       <li><a href="mailto:hello@peerlibrary.org">Contact</a></li>
     </ul>
+    {{> backgroundPause}}
   </footer>
 </template>
 
-<template name="backgroundPauseButton">
+<template name="backgroundPause">
+  <div class="background-pause">
     <button>
       {{#if backgroundPaused}}
-      Start Background
+        Resume Background
       {{else}}
-      Stop Background
+        Pause Background
       {{/if}}
     </button>
+  </div>
 </template>
 
 <template name="baseFooter">


### PR DESCRIPTION
I currently set href to "" because I don't currently know how to interface with session variables directly through html tags. "Basic View" and "Standard View" have different lengths, so the footer shifts when the button is pressed. The paused background state is different from the paused state when the user once again switches to the tab after a period of time, where the triangles are all orange and regular. The session variable can also be renamed and used elsewhere to perhaps make the page less reactive, for example in displaying search results, to reduce lag.
